### PR TITLE
feat: wasm-opt version to be installed

### DIFF
--- a/src/install/mod.rs
+++ b/src/install/mod.rs
@@ -25,6 +25,13 @@ pub use self::mode::InstallMode;
 pub use self::os::Os;
 pub use self::tool::Tool;
 
+/// The version of wasm-opt that will be downloaded and used for optimizing the wasm output.
+///
+/// E.g. `version_122`
+///
+// Make sure to update the version in docs/src/cargo-toml-configuration.md as well
+pub const WASM_OPT_VERSION: u32 = 117;
+
 /// Possible outcomes of attempting to find/install a tool
 pub enum Status {
     /// Couldn't install tool because downloads are forbidden by user
@@ -201,9 +208,9 @@ pub fn prebuilt_url_for(tool: &Tool, version: &str, arch: &Arch, os: &Os) -> Res
             ))
         },
         Tool::WasmOpt => {
+            let version = format!("version_{}", WASM_OPT_VERSION);
             Ok(format!(
-        "https://github.com/WebAssembly/binaryen/releases/download/{vers}/binaryen-{vers}-{target}.tar.gz",
-        vers = "version_117", // Make sure to update the version in docs/src/cargo-toml-configuration.md as well
+        "https://github.com/WebAssembly/binaryen/releases/download/{version}/binaryen-{version}-{target}.tar.gz",
         target = target,
             ))
         }

--- a/src/wasm_opt.rs
+++ b/src/wasm_opt.rs
@@ -18,7 +18,10 @@ pub fn run(cache: &Cache, out_dir: &Path, args: &[String], install_permitted: bo
         None => return Ok(()),
     };
 
-    PBAR.info("Optimizing wasm binaries with `wasm-opt`...");
+    PBAR.info(&format!(
+        "Optimizing wasm binaries with `wasm-opt@{version}`...",
+        version = install::WASM_OPT_VERSION
+    ));
 
     for file in out_dir.read_dir()? {
         let file = file?;


### PR DESCRIPTION
A small improvement to show which version of wasm-opt is to be used/installed.

- [x] You have the latest version of `rustfmt` installed
```bash
$ rustup component add rustfmt
```
- [x] You ran `cargo fmt` on the code base before submitting
- [ ] ~~You reference which issue is being closed in the PR text~~ not applicable
